### PR TITLE
IPv6 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.11
+
+WORKDIR /peerdiscovery
+COPY . .
+RUN go build ./examples/main.go
+
+CMD ["/peerdiscovery/main"]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,23 @@ Here's the output when running on two computers. (*Run these gifs in sync by hit
 For more examples, see [the scanning example](https://github.com/schollz/peerdiscovery/blob/master/examples/main.go) or [the docs](https://godoc.org/github.com/schollz/peerdiscovery).
 
 
+## Testing
+
+To test the peer discovery with just one host, one can launch multiple containers. The provided `Dockerfile` will run the example code.
+Please make sure to enable [Docker's IPv6 support](https://docs.docker.com/v17.09/engine/userguide/networking/default_network/ipv6/) if you are using IPv6 for peer discovery.
+
+```console
+# Build the container, named peertest
+$ docker build -t peertest .
+
+# Execute the following command in multiple terminals
+$ docker run -t --rm peertest
+Scanning for 10 seconds to find LAN peers
+ 100% |████████████████████████████████████████|  [9s:0s]Found 1 other computers
+0) '172.17.0.2' with payload 'zqrecHipCO'
+```
+
+
 ## Contributing
 
 Pull requests are welcome. Feel free to...

--- a/go.mod
+++ b/go.mod
@@ -2,5 +2,6 @@ module github.com/schollz/peerdiscovery
 
 require (
 	github.com/schollz/progressbar/v2 v2.5.3
+	github.com/stretchr/testify v1.3.0
 	golang.org/x/net v0.0.0-20180906233101-161cd47e91fd
 )

--- a/peerdiscovery.go
+++ b/peerdiscovery.go
@@ -1,6 +1,7 @@
 package peerdiscovery
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
@@ -8,6 +9,15 @@ import (
 	"time"
 
 	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+// IPVersion specifies the version of the Internet Protocol to be used.
+type IPVersion uint
+
+const (
+	IPv4 IPVersion = 4
+	IPv6 IPVersion = 6
 )
 
 // Discovered is the structure of the discovered peers,
@@ -29,9 +39,9 @@ type Settings struct {
 	// The default port is 9999.
 	Port string
 	// MulticastAddress specifies the multicast address.
-	// You should be able to use any between 224.0.0.0 to 239.255.255.255.
+	// You should be able to use any of 224.0.0.0/4 or ff00::/8.
 	// By default it uses the Simple Service Discovery Protocol
-	// address (239.255.255.250).
+	// address (239.255.255.250 for IPv4 or ff02::c for IPv6).
 	MulticastAddress string
 	// Payload is the bytes that are sent out with each broadcast. Must be short.
 	Payload []byte
@@ -44,9 +54,11 @@ type Settings struct {
 	AllowSelf bool
 	// DisableBroadcast will not allow sending out a broadcast
 	DisableBroadcast bool
+	// IPVersion specifies the version of the Internet Protocol (default IPv4)
+	IPVersion IPVersion
 
 	portNum                 int
-	multicastAddressNumbers []uint8
+	multicastAddressNumbers net.IP
 }
 
 // peerDiscovery is the object that can do the discovery for finding LAN peers.
@@ -72,8 +84,15 @@ func initialize(settings Settings) (p *peerDiscovery, err error) {
 	if p.settings.Port == "" {
 		p.settings.Port = "9999"
 	}
+	if p.settings.IPVersion == 0 {
+		p.settings.IPVersion = IPv4
+	}
 	if p.settings.MulticastAddress == "" {
-		p.settings.MulticastAddress = "239.255.255.250"
+		if p.settings.IPVersion == IPv4 {
+			p.settings.MulticastAddress = "239.255.255.250"
+		} else {
+			p.settings.MulticastAddress = "ff02::c"
+		}
 	}
 	if len(p.settings.Payload) == 0 {
 		p.settings.Payload = []byte("hi")
@@ -85,14 +104,11 @@ func initialize(settings Settings) (p *peerDiscovery, err error) {
 		p.settings.TimeLimit = 10 * time.Second
 	}
 	p.received = make(map[string][]byte)
-	p.settings.multicastAddressNumbers = []uint8{0, 0, 0, 0}
-	for i, num := range strings.Split(p.settings.MulticastAddress, ".") {
-		var nInt int
-		nInt, err = strconv.Atoi(num)
-		if err != nil {
-			return
-		}
-		p.settings.multicastAddressNumbers[i] = uint8(nInt)
+	p.settings.multicastAddressNumbers = net.ParseIP(p.settings.MulticastAddress)
+	if p.settings.multicastAddressNumbers == nil {
+		err = fmt.Errorf("Multicast Address %s could not be converted to an IP",
+			p.settings.MulticastAddress)
+		return
 	}
 	p.settings.portNum, err = strconv.Atoi(p.settings.Port)
 	if err != nil {
@@ -116,8 +132,10 @@ func Discover(settings ...Settings) (discoveries []Discovered, err error) {
 
 	p.RLock()
 	address := p.settings.MulticastAddress + ":" + p.settings.Port
+	if p.settings.IPVersion == IPv6 {
+		address = "[" + p.settings.MulticastAddress + "]:" + p.settings.Port
+	}
 	portNum := p.settings.portNum
-	multicastAddressNumbers := p.settings.multicastAddressNumbers
 	payload := p.settings.Payload
 	tickerDuration := p.settings.Delay
 	timeLimit := p.settings.TimeLimit
@@ -130,19 +148,31 @@ func Discover(settings ...Settings) (discoveries []Discovered, err error) {
 	}
 
 	// Open up a connection
-	c, err := net.ListenPacket("udp4", address)
+	network := "udp4"
+	if p.settings.IPVersion == IPv6 {
+		network = "udp6"
+	}
+	c, err := net.ListenPacket(network, address)
 	if err != nil {
 		return
 	}
 	defer c.Close()
 
-	group := net.IPv4(multicastAddressNumbers[0], multicastAddressNumbers[1], multicastAddressNumbers[2], multicastAddressNumbers[3])
-	p2 := ipv4.NewPacketConn(c)
+	group := p.settings.multicastAddressNumbers
+
+	// ipv{4,6} have an own PacketConn, which does not implement net.PacketConn
+	var p2 interface{}
+	if p.settings.IPVersion == IPv4 {
+		p2 = ipv4.NewPacketConn(c)
+	} else {
+		p2 = ipv6.NewPacketConn(c)
+	}
 
 	for i := range ifaces {
-		if errJoinGroup := p2.JoinGroup(&ifaces[i], &net.UDPAddr{IP: group, Port: portNum}); errJoinGroup != nil {
-			// log.Print(errJoinGroup)
-			continue
+		if p.settings.IPVersion == IPv4 {
+			p2.(*ipv4.PacketConn).JoinGroup(&ifaces[i], &net.UDPAddr{IP: group, Port: portNum})
+		} else {
+			p2.(*ipv6.PacketConn).JoinGroup(&ifaces[i], &net.UDPAddr{IP: group, Port: portNum})
 		}
 	}
 
@@ -162,14 +192,28 @@ func Discover(settings ...Settings) (discoveries []Discovered, err error) {
 			// write to multicast
 			dst := &net.UDPAddr{IP: group, Port: portNum}
 			for i := range ifaces {
-				if errMulticast := p2.SetMulticastInterface(&ifaces[i]); errMulticast != nil {
-					// log.Print(errMulticast)
-					continue
-				}
-				p2.SetMulticastTTL(2)
-				if _, errMulticast := p2.WriteTo([]byte(payload), nil, dst); errMulticast != nil {
-					// log.Print(errMulticast)
-					continue
+				if p.settings.IPVersion == IPv4 {
+					p24 := p2.(*ipv4.PacketConn)
+					if errMulticast := p24.SetMulticastInterface(&ifaces[i]); errMulticast != nil {
+						// log.Print(errMulticast)
+						continue
+					}
+					p24.SetMulticastTTL(2)
+					if _, errMulticast := p24.WriteTo([]byte(payload), nil, dst); errMulticast != nil {
+						// log.Print(errMulticast)
+						continue
+					}
+				} else {
+					p26 := p2.(*ipv6.PacketConn)
+					if errMulticast := p26.SetMulticastInterface(&ifaces[i]); errMulticast != nil {
+						// log.Print(errMulticast)
+						continue
+					}
+					p26.SetMulticastHopLimit(2)
+					if _, errMulticast := p26.WriteTo([]byte(payload), nil, dst); errMulticast != nil {
+						// log.Print(errMulticast)
+						continue
+					}
 				}
 			}
 		}
@@ -183,12 +227,24 @@ func Discover(settings ...Settings) (discoveries []Discovered, err error) {
 		// send out broadcast that is finished
 		dst := &net.UDPAddr{IP: group, Port: portNum}
 		for i := range ifaces {
-			if errMulticast := p2.SetMulticastInterface(&ifaces[i]); errMulticast != nil {
-				continue
-			}
-			p2.SetMulticastTTL(2)
-			if _, errMulticast := p2.WriteTo([]byte(payload), nil, dst); errMulticast != nil {
-				continue
+			if p.settings.IPVersion == IPv4 {
+				p24 := p2.(*ipv4.PacketConn)
+				if errMulticast := p24.SetMulticastInterface(&ifaces[i]); errMulticast != nil {
+					continue
+				}
+				p24.SetMulticastTTL(2)
+				if _, errMulticast := p24.WriteTo([]byte(payload), nil, dst); errMulticast != nil {
+					continue
+				}
+			} else {
+				p26 := p2.(*ipv6.PacketConn)
+				if errMulticast := p26.SetMulticastInterface(&ifaces[i]); errMulticast != nil {
+					continue
+				}
+				p26.SetMulticastHopLimit(2)
+				if _, errMulticast := p26.WriteTo([]byte(payload), nil, dst); errMulticast != nil {
+					continue
+				}
 			}
 		}
 	}
@@ -217,8 +273,10 @@ const (
 func (p *peerDiscovery) listen() (recievedBytes []byte, err error) {
 	p.RLock()
 	address := p.settings.MulticastAddress + ":" + p.settings.Port
+	if p.settings.IPVersion == IPv6 {
+		address = "[" + p.settings.MulticastAddress + "]:" + p.settings.Port
+	}
 	portNum := p.settings.portNum
-	multicastAddressNumbers := p.settings.multicastAddressNumbers
 	allowSelf := p.settings.AllowSelf
 	p.RUnlock()
 	localIPs := getLocalIPs()
@@ -231,41 +289,62 @@ func (p *peerDiscovery) listen() (recievedBytes []byte, err error) {
 	// log.Println(ifaces)
 
 	// Open up a connection
-	c, err := net.ListenPacket("udp4", address)
+	network := "udp4"
+	if p.settings.IPVersion == IPv6 {
+		network = "udp6"
+	}
+	c, err := net.ListenPacket(network, address)
 	if err != nil {
 		return
 	}
 	defer c.Close()
 
-	group := net.IPv4(multicastAddressNumbers[0], multicastAddressNumbers[1], multicastAddressNumbers[2], multicastAddressNumbers[3])
-	p2 := ipv4.NewPacketConn(c)
+	group := p.settings.multicastAddressNumbers
+	var p2 interface{}
+	if p.settings.IPVersion == IPv4 {
+		p2 = ipv4.NewPacketConn(c)
+	} else {
+		p2 = ipv6.NewPacketConn(c)
+	}
+
 	for i := range ifaces {
-		if errJoinGroup := p2.JoinGroup(&ifaces[i], &net.UDPAddr{IP: group, Port: portNum}); errJoinGroup != nil {
-			// log.Print(errJoinGroup)
-			continue
+		if p.settings.IPVersion == IPv4 {
+			p2.(*ipv4.PacketConn).JoinGroup(&ifaces[i], &net.UDPAddr{IP: group, Port: portNum})
+		} else {
+			p2.(*ipv6.PacketConn).JoinGroup(&ifaces[i], &net.UDPAddr{IP: group, Port: portNum})
 		}
 	}
 
 	// Loop forever reading from the socket
 	for {
 		buffer := make([]byte, maxDatagramSize)
-		n, _, src, errRead := p2.ReadFrom(buffer)
+		var (
+			n       int
+			src     net.Addr
+			errRead error
+		)
+		if p.settings.IPVersion == IPv4 {
+			n, _, src, errRead = p2.(*ipv4.PacketConn).ReadFrom(buffer)
+		} else {
+			n, _, src, errRead = p2.(*ipv6.PacketConn).ReadFrom(buffer)
+		}
 		// log.Println(n, src.String(), err, buffer[:n])
 		if errRead != nil {
 			err = errRead
 			return
 		}
 
-		if _, ok := localIPs[strings.Split(src.String(), ":")[0]]; ok && !allowSelf {
+		srcHost, _, _ := net.SplitHostPort(src.String())
+
+		if _, ok := localIPs[srcHost]; ok && !allowSelf {
 			continue
 		}
 
 		// log.Println(src, hex.Dump(buffer[:n]))
 
-		ip := strings.Split(src.String(), ":")[0]
 		p.Lock()
-		if _, ok := p.received[ip]; !ok {
-			p.received[ip] = buffer[:n]
+		if _, ok := p.received[srcHost]; !ok {
+			p.received[srcHost] = buffer[:n]
 		}
 		p.Unlock()
 		p.RLock()
@@ -284,6 +363,7 @@ func getLocalIPs() (ips map[string]struct{}) {
 	ips = make(map[string]struct{})
 	ips["localhost"] = struct{}{}
 	ips["127.0.0.1"] = struct{}{}
+	ips["::1"] = struct{}{}
 	addrs, err := net.InterfaceAddrs()
 	if err != nil {
 		return

--- a/peerdiscovery.go
+++ b/peerdiscovery.go
@@ -130,10 +130,7 @@ func Discover(settings ...Settings) (discoveries []Discovered, err error) {
 	}
 
 	p.RLock()
-	address := p.settings.MulticastAddress + ":" + p.settings.Port
-	if p.settings.IPVersion == IPv6 {
-		address = "[" + p.settings.MulticastAddress + "]:" + p.settings.Port
-	}
+	address := net.JoinHostPort(p.settings.MulticastAddress, p.settings.Port)
 	portNum := p.settings.portNum
 	payload := p.settings.Payload
 	tickerDuration := p.settings.Delay
@@ -147,11 +144,7 @@ func Discover(settings ...Settings) (discoveries []Discovered, err error) {
 	}
 
 	// Open up a connection
-	network := "udp4"
-	if p.settings.IPVersion == IPv6 {
-		network = "udp6"
-	}
-	c, err := net.ListenPacket(network, address)
+	c, err := net.ListenPacket(fmt.Sprintf("udp%d", p.settings.IPVersion), address)
 	if err != nil {
 		return
 	}
@@ -271,10 +264,7 @@ const (
 // from that address to a buffer which is passed to a hander
 func (p *peerDiscovery) listen() (recievedBytes []byte, err error) {
 	p.RLock()
-	address := p.settings.MulticastAddress + ":" + p.settings.Port
-	if p.settings.IPVersion == IPv6 {
-		address = "[" + p.settings.MulticastAddress + "]:" + p.settings.Port
-	}
+	address := net.JoinHostPort(p.settings.MulticastAddress, p.settings.Port)
 	portNum := p.settings.portNum
 	allowSelf := p.settings.AllowSelf
 	p.RUnlock()
@@ -288,11 +278,7 @@ func (p *peerDiscovery) listen() (recievedBytes []byte, err error) {
 	// log.Println(ifaces)
 
 	// Open up a connection
-	network := "udp4"
-	if p.settings.IPVersion == IPv6 {
-		network = "udp6"
-	}
-	c, err := net.ListenPacket(network, address)
+	c, err := net.ListenPacket(fmt.Sprintf("udp%d", p.settings.IPVersion), address)
 	if err != nil {
 		return
 	}

--- a/peerdiscovery_test.go
+++ b/peerdiscovery_test.go
@@ -8,42 +8,48 @@ import (
 )
 
 func TestDiscovery(t *testing.T) {
-	// should not be able to "discover" itself
-	discoveries, err := Discover()
-	assert.Nil(t, err)
-	assert.Zero(t, len(discoveries))
+	for _, version := range []IPVersion{IPv4, IPv6} {
+		// should not be able to "discover" itself
+		discoveries, err := Discover()
+		assert.Nil(t, err)
+		assert.Zero(t, len(discoveries))
 
-	// should be able to "discover" itself
-	discoveries, err = Discover(Settings{
-		Limit:     -1,
-		AllowSelf: true,
-		Payload:   []byte("payload"),
-		Delay:     500 * time.Millisecond,
-		TimeLimit: 1 * time.Second,
-	})
-	assert.Nil(t, err)
-	assert.NotZero(t, len(discoveries))
+		// should be able to "discover" itself
+		discoveries, err = Discover(Settings{
+			Limit:     -1,
+			AllowSelf: true,
+			Payload:   []byte("payload"),
+			Delay:     500 * time.Millisecond,
+			TimeLimit: 1 * time.Second,
+			IPVersion: version,
+		})
+		assert.Nil(t, err)
+		assert.NotZero(t, len(discoveries))
+	}
 }
 
 func TestDiscoverySelf(t *testing.T) {
-	// broadcast self to self
-	go func() {
-		_, err := Discover(Settings{
-			Limit:     -1,
-			Payload:   []byte("payload"),
-			Delay:     10 * time.Millisecond,
-			TimeLimit: 1 * time.Second,
+	for _, version := range []IPVersion{IPv4, IPv6} {
+		// broadcast self to self
+		go func() {
+			_, err := Discover(Settings{
+				Limit:     -1,
+				Payload:   []byte("payload"),
+				Delay:     10 * time.Millisecond,
+				TimeLimit: 1 * time.Second,
+				IPVersion: version,
+			})
+			assert.Nil(t, err)
+		}()
+		discoveries, err := Discover(Settings{
+			Limit:            1,
+			Payload:          []byte("payload"),
+			Delay:            500 * time.Millisecond,
+			TimeLimit:        1 * time.Second,
+			DisableBroadcast: true,
+			AllowSelf:        true,
 		})
 		assert.Nil(t, err)
-	}()
-	discoveries, err := Discover(Settings{
-		Limit:            1,
-		Payload:          []byte("payload"),
-		Delay:            500 * time.Millisecond,
-		TimeLimit:        1 * time.Second,
-		DisableBroadcast: true,
-		AllowSelf:        true,
-	})
-	assert.Nil(t, err)
-	assert.NotZero(t, len(discoveries))
+		assert.NotZero(t, len(discoveries))
+	}
 }


### PR DESCRIPTION
This pull request adds IPv6 multicast scans by introducing the `IPVersion` field to the `Settings` struct, defaulting to `IPv4` to not break the compatibility. However, settings `IPVersion: IPv6` will execute the same peer discovery service, just for IPv6 instead.

The code is a bit ugly at some points, because both `ipv4.PacketConn` and `ipv6.PacketConn` does not implement `net.PacketConn`. Therefore I treated them as an empty interface.

Please tell me what you think and thanks a lot for this library!

---

*Random note regarding testing:* I wrote a small `Dockerfile` which launches - after [enabling IPv6](https://docs.docker.com/v17.09/engine/userguide/networking/default_network/ipv6/) - some containers for testing.

```
$ cat Dockerfile
FROM golang:1.11

WORKDIR /peerdiscovery
COPY . .
RUN go build ./examples/main.go

CMD ["/peerdiscovery/main"]

$ docker build -t peertest .
. . .

# run the following command in multiple terminals
$ docker run -t --rm peertest
```