### PR TITLE
Enable broadcast at startup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80
 	golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3 // indirect
 )
+
+go 1.13

--- a/peerdiscovery_test.go
+++ b/peerdiscovery_test.go
@@ -10,7 +10,10 @@ import (
 func TestDiscovery(t *testing.T) {
 	for _, version := range []IPVersion{IPv4, IPv6} {
 		// should not be able to "discover" itself
-		discoveries, err := Discover()
+		discoveries, err := Discover(Settings{
+			TimeLimit: 5 * time.Second,
+			Delay:     500 * time.Millisecond,
+		})
 		assert.Nil(t, err)
 		assert.Zero(t, len(discoveries))
 


### PR DESCRIPTION
Ticker channels are not triggerred upon initialization, so the first
broadcast would be forced to wait `delay` duration.  This wait is
unexpected, as the user can assume that the first message is sent
immediately.