### PR TITLE
Fix StopChan behaviour

### DIFF
--- a/peerdiscovery.go
+++ b/peerdiscovery.go
@@ -190,6 +190,7 @@ func Discover(settings ...Settings) (discoveries []Discovered, err error) {
 	ticker := time.NewTicker(tickerDuration)
 	defer ticker.Stop()
 	start := time.Now()
+
 	for {
 		exit := false
 
@@ -204,16 +205,15 @@ func Discover(settings ...Settings) (discoveries []Discovered, err error) {
 			broadcast(p2, payload, ifaces, &net.UDPAddr{IP: group, Port: portNum})
 		}
 
-		if exit || timeLimit > 0 && time.Since(start) > timeLimit {
-			break
-		}
-
 		select {
 		case <-p.settings.StopChan:
 			exit = true
 		case <-ticker.C:
 		}
 
+		if exit || timeLimit > 0 && time.Since(start) > timeLimit {
+			break
+		}
 	}
 
 	if !s.DisableBroadcast {


### PR DESCRIPTION
This seems to fix the exit behaviour, since the `exit` variable was created for the `for` loop scope, setting it to true at the _end_ of the loop meant it wasn't being caught by the check on line [214](https://github.com/schollz/peerdiscovery/pull/14/files#diff-6be615f323e4f621692a555f64b4107bR214).

I wasn't sure if we should just move the `if` to under the `select`, but this seemed like the lowest-impact fix.

Thanks for this module! :) 