### PR TITLE
Make sure listening Go routine exits when done

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -1,7 +1,6 @@
 package peerdiscovery
 
 import (
-	"fmt"
 	"net"
 	"sync"
 	"time"
@@ -82,9 +81,8 @@ func (p *PeerDiscovery) ActivePeers() (peers []*PeerState) {
 
 // Listen binds to the UDP address and port given and writes packets received
 // from that address to a buffer which is passed to a hander
-func (p *PeerDiscovery) listen() (recievedBytes []byte, err error) {
+func (p *PeerDiscovery) listen(c net.PacketConn) (recievedBytes []byte, err error) {
 	p.RLock()
-	address := net.JoinHostPort(p.settings.MulticastAddress, p.settings.Port)
 	portNum := p.settings.portNum
 	allowSelf := p.settings.AllowSelf
 	timeLimit := p.settings.TimeLimit
@@ -98,13 +96,6 @@ func (p *PeerDiscovery) listen() (recievedBytes []byte, err error) {
 		return nil, err
 	}
 	// log.Println(ifaces)
-
-	// Open up a connection
-	c, err := net.ListenPacket(fmt.Sprintf("udp%d", p.settings.IPVersion), address)
-	if err != nil {
-		return nil, err
-	}
-	defer c.Close()
 
 	group := p.settings.multicastAddressNumbers
 	var p2 NetPacketConn

--- a/peerdiscovery.go
+++ b/peerdiscovery.go
@@ -167,7 +167,7 @@ func newPeerDiscovery(settings ...Settings) (pd *PeerDiscovery, discoveries []Di
 		p2.JoinGroup(&ifaces[i], &net.UDPAddr{IP: group, Port: portNum})
 	}
 
-	go p.listen()
+	go p.listen(c)
 	ticker := time.NewTicker(tickerDuration)
 	defer ticker.Stop()
 	start := time.Now()


### PR DESCRIPTION
A proposal. Use a deadline for the read operation in the Go routine. In case the routine is supposed to shut down but no traffic is happening on the multicast address this routine never gets the chance to quit.

Instead time out the read operation after 5 seconds of no data and check whether shut down is expected.

~~Note that this is done against `master` branch. In case #29 gets accepted in some form the check for shutdown should be extended here too.~~
