### PR TITLE
Various improvements

### DIFF
--- a/internal.go
+++ b/internal.go
@@ -1,0 +1,155 @@
+package peerdiscovery
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+)
+
+// initialize returns a new peerDiscovery object which can be used to discover peers.
+// The settings are optional. If any setting is not supplied, then defaults are used.
+// See the Settings for more information.
+func initialize(settings Settings) (p *PeerDiscovery, err error) {
+	p = new(PeerDiscovery)
+	p.Lock()
+	defer p.Unlock()
+
+	// initialize settings
+	p.settings = settings
+
+	// defaults
+	if p.settings.Port == "" {
+		p.settings.Port = "9999"
+	}
+	if p.settings.IPVersion == 0 {
+		p.settings.IPVersion = IPv4
+	}
+	if p.settings.MulticastAddress == "" {
+		if p.settings.IPVersion == IPv4 {
+			p.settings.MulticastAddress = "239.255.255.250"
+		} else {
+			p.settings.MulticastAddress = "ff02::c"
+		}
+	}
+	if len(p.settings.Payload) == 0 {
+		p.settings.Payload = []byte("hi")
+	}
+	if p.settings.Delay == 0 {
+		p.settings.Delay = 1 * time.Second
+	}
+	if p.settings.TimeLimit == 0 {
+		p.settings.TimeLimit = 10 * time.Second
+	}
+	if p.settings.StopChan == nil {
+		p.settings.StopChan = make(chan struct{})
+	}
+	p.received = make(map[string]*PeerState)
+	p.settings.multicastAddressNumbers = net.ParseIP(p.settings.MulticastAddress)
+	if p.settings.multicastAddressNumbers == nil {
+		err = fmt.Errorf(
+			"multicast address %s could not be converted to an IP",
+			p.settings.MulticastAddress,
+		)
+
+		return
+	}
+	p.settings.portNum, err = strconv.Atoi(p.settings.Port)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// filterInterfaces returns a list of valid network interfaces
+func filterInterfaces(useIpv4 bool) (ifaces []net.Interface, err error) {
+	allIfaces, err := net.Interfaces()
+	if err != nil {
+		return
+	}
+
+	for _, iface := range allIfaces {
+		// Interface must be up and either support multicast or be a loopback interface.
+		if iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+		if iface.Flags&net.FlagLoopback == 0 && iface.Flags&net.FlagMulticast == 0 {
+			continue
+		}
+
+		addrs, addrsErr := iface.Addrs()
+		if addrsErr != nil {
+			err = addrsErr
+			return
+		}
+
+		supported := false
+		for j := range addrs {
+			addr, ok := addrs[j].(*net.IPNet)
+			if !ok {
+				continue
+			}
+			if addr == nil || addr.IP == nil {
+				continue
+			}
+
+			// An IP can either be an IPv4 or an IPv6 address.
+			// Check if the desired familiy is used.
+			familiyMatches := (addr.IP.To4() != nil) == useIpv4
+			if familiyMatches {
+				supported = true
+				break
+			}
+		}
+
+		if supported {
+			ifaces = append(ifaces, iface)
+		}
+	}
+
+	return
+}
+
+// getLocalIPs returns the local ip address
+func getLocalIPs() (ips map[string]struct{}) {
+	ips = make(map[string]struct{})
+	ips["localhost"] = struct{}{}
+	ips["127.0.0.1"] = struct{}{}
+	ips["::1"] = struct{}{}
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return
+	}
+
+	for _, iface := range ifaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+
+		for _, address := range addrs {
+			ip, _, err := net.ParseCIDR(address.String())
+			if err != nil {
+				// log.Printf("Failed to parse %s: %v", address.String(), err)
+				continue
+			}
+
+			ips[ip.String()+"%"+iface.Name] = struct{}{}
+			ips[ip.String()] = struct{}{}
+		}
+	}
+	return
+}
+
+func broadcast(p2 NetPacketConn, payload []byte, ifaces []net.Interface, dst net.Addr) {
+	for i := range ifaces {
+		if errMulticast := p2.SetMulticastInterface(&ifaces[i]); errMulticast != nil {
+			continue
+		}
+		p2.SetMulticastTTL(2)
+		if _, errMulticast := p2.WriteTo([]byte(payload), dst); errMulticast != nil {
+			continue
+		}
+	}
+}

--- a/listener.go
+++ b/listener.go
@@ -1,0 +1,178 @@
+package peerdiscovery
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+const (
+	// https://en.wikipedia.org/wiki/User_Datagram_Protocol#Packet_structure
+	maxDatagramSize = 66507
+)
+
+// PeerState is the state of a peer that has been discovered.
+// It contains the address of the peer, the last time it was seen,
+// the last payload it sent, and the metadata associated with it.
+// To update the metadata, assign your own metadata to the Metadata.Data field.
+// The metadata is not protected by a mutex, so you must do this yourself.
+type PeerState struct {
+	Address     string
+	lastSeen    time.Time
+	lastPayload []byte
+	metadata    *Metadata
+}
+
+type LostPeer struct {
+	Address     string
+	LastSeen    time.Time
+	LastPayload []byte
+	Metadata    *Metadata
+}
+
+func (p *PeerDiscovery) gc() {
+	ticker := time.NewTicker(p.settings.Delay * 2)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		p.Lock()
+		for ip, peerState := range p.received {
+			if time.Since(peerState.lastSeen) > p.settings.Delay*4 {
+				if p.settings.NotifyLost != nil {
+					p.settings.NotifyLost(LostPeer{
+						Address:     ip,
+						LastSeen:    peerState.lastSeen,
+						LastPayload: peerState.lastPayload,
+						Metadata:    peerState.metadata,
+					})
+				}
+
+				delete(p.received, ip)
+			}
+		}
+		p.Unlock()
+	}
+}
+
+// PeerDiscovery is the object that can do the discovery for finding LAN peers.
+type PeerDiscovery struct {
+	settings Settings
+
+	received map[string]*PeerState
+	sync.RWMutex
+	exit bool
+}
+
+func (p *PeerDiscovery) Shutdown() {
+	p.exit = true
+}
+
+func (p *PeerDiscovery) ActivePeers() (peers []*PeerState) {
+	p.RLock()
+	defer p.RUnlock()
+	for _, peerState := range p.received {
+		peers = append(peers, peerState)
+	}
+	return
+}
+
+// Listen binds to the UDP address and port given and writes packets received
+// from that address to a buffer which is passed to a hander
+func (p *PeerDiscovery) listen() (recievedBytes []byte, err error) {
+	p.RLock()
+	address := net.JoinHostPort(p.settings.MulticastAddress, p.settings.Port)
+	portNum := p.settings.portNum
+	allowSelf := p.settings.AllowSelf
+	timeLimit := p.settings.TimeLimit
+	notify := p.settings.Notify
+	p.RUnlock()
+	localIPs := getLocalIPs()
+
+	// get interfaces
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+	// log.Println(ifaces)
+
+	// Open up a connection
+	c, err := net.ListenPacket(fmt.Sprintf("udp%d", p.settings.IPVersion), address)
+	if err != nil {
+		return nil, err
+	}
+	defer c.Close()
+
+	group := p.settings.multicastAddressNumbers
+	var p2 NetPacketConn
+	if p.settings.IPVersion == IPv4 {
+		p2 = PacketConn4{ipv4.NewPacketConn(c)}
+	} else {
+		p2 = PacketConn6{ipv6.NewPacketConn(c)}
+	}
+
+	for i := range ifaces {
+		p2.JoinGroup(&ifaces[i], &net.UDPAddr{IP: group, Port: portNum})
+	}
+
+	start := time.Now()
+	// Loop forever reading from the socket
+	for {
+		buffer := make([]byte, maxDatagramSize)
+		var (
+			n       int
+			src     net.Addr
+			errRead error
+		)
+		n, src, errRead = p2.ReadFrom(buffer)
+		if errRead != nil {
+			err = errRead
+			return
+		}
+
+		srcHost, _, _ := net.SplitHostPort(src.String())
+
+		if _, ok := localIPs[srcHost]; ok && !allowSelf {
+			continue
+		}
+
+		// log.Println(src, hex.Dump(buffer[:n]))
+
+		p.Lock()
+		if peer, ok := p.received[srcHost]; ok {
+			peer.lastSeen = time.Now()
+			peer.lastPayload = buffer[:n]
+		} else {
+			p.received[srcHost] = &PeerState{
+				Address:     srcHost,
+				lastPayload: buffer[:n],
+				lastSeen:    time.Now(),
+				metadata:    &Metadata{},
+			}
+		}
+		p.Unlock()
+
+		if notify != nil {
+			notify(Discovered{
+				Address: srcHost,
+				Payload: buffer[:n],
+			})
+		}
+
+		p.RLock()
+		if len(p.received) >= p.settings.Limit && p.settings.Limit > 0 {
+			p.RUnlock()
+			break
+		}
+		if p.exit || timeLimit > 0 && time.Since(start) > timeLimit {
+			p.RUnlock()
+			break
+		}
+		p.RUnlock()
+	}
+
+	return
+}

--- a/packetConn.go
+++ b/packetConn.go
@@ -1,0 +1,43 @@
+package peerdiscovery
+
+import (
+	"net"
+
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+type PacketConn4 struct {
+	*ipv4.PacketConn
+}
+
+// ReadFrom wraps the ipv4 ReadFrom without a control message
+func (pc4 PacketConn4) ReadFrom(buf []byte) (int, net.Addr, error) {
+	n, _, addr, err := pc4.PacketConn.ReadFrom(buf)
+	return n, addr, err
+}
+
+// WriteTo wraps the ipv4 WriteTo without a control message
+func (pc4 PacketConn4) WriteTo(buf []byte, dst net.Addr) (int, error) {
+	return pc4.PacketConn.WriteTo(buf, nil, dst)
+}
+
+type PacketConn6 struct {
+	*ipv6.PacketConn
+}
+
+// ReadFrom wraps the ipv6 ReadFrom without a control message
+func (pc6 PacketConn6) ReadFrom(buf []byte) (int, net.Addr, error) {
+	n, _, addr, err := pc6.PacketConn.ReadFrom(buf)
+	return n, addr, err
+}
+
+// WriteTo wraps the ipv6 WriteTo without a control message
+func (pc6 PacketConn6) WriteTo(buf []byte, dst net.Addr) (int, error) {
+	return pc6.PacketConn.WriteTo(buf, nil, dst)
+}
+
+// SetMulticastTTL wraps the hop limit of ipv6
+func (pc6 PacketConn6) SetMulticastTTL(i int) error {
+	return pc6.SetMulticastHopLimit(i)
+}

--- a/peerdiscovery_test.go
+++ b/peerdiscovery_test.go
@@ -41,7 +41,7 @@ func TestDiscoverySelf(t *testing.T) {
 				Limit:     -1,
 				Payload:   []byte("payload"),
 				Delay:     10 * time.Millisecond,
-				TimeLimit: 1 * time.Second,
+				TimeLimit: 2 * time.Second,
 				IPVersion: version,
 			})
 			assert.Nil(t, err)
@@ -50,7 +50,7 @@ func TestDiscoverySelf(t *testing.T) {
 			Limit:            1,
 			Payload:          []byte("payload"),
 			Delay:            500 * time.Millisecond,
-			TimeLimit:        1 * time.Second,
+			TimeLimit:        2 * time.Second,
 			DisableBroadcast: true,
 			AllowSelf:        true,
 		})


### PR DESCRIPTION
- **Restructure the library**: the library was split into several files to make keeping only the necessary context a bit easier
- **GC for lost peers**: for long-running apps it's useful to have some way to know if we didn't see a peer for a while
- **Introduce support for peer metadata** + **Lost peer notifications**: useful if you want to store some information relevant to this specific peer to perform something upon loosing the peer
- **Shutdown support**: simple way to stop the listener
- Fix a few error shadowing issues

I made my best effort to keep the backwards compatibility, and as far as I know this PR should be backward-compatible.