### PR TITLE
Fix various typos in documentation

### DIFF
--- a/internal.go
+++ b/internal.go
@@ -94,9 +94,9 @@ func filterInterfaces(useIpv4 bool) (ifaces []net.Interface, err error) {
 			}
 
 			// An IP can either be an IPv4 or an IPv6 address.
-			// Check if the desired familiy is used.
-			familiyMatches := (addr.IP.To4() != nil) == useIpv4
-			if familiyMatches {
+			// Check if the desired family is used.
+			familyMatches := (addr.IP.To4() != nil) == useIpv4
+			if familyMatches {
 				supported = true
 				break
 			}

--- a/listener.go
+++ b/listener.go
@@ -81,8 +81,8 @@ func (p *PeerDiscovery) ActivePeers() (peers []*PeerState) {
 }
 
 // Listen binds to the UDP address and port given and writes packets received
-// from that address to a buffer which is passed to a hander
-func (p *PeerDiscovery) listen() (recievedBytes []byte, err error) {
+// from that address to a buffer which is passed to a handler
+func (p *PeerDiscovery) listen() (receivedBytes []byte, err error) {
 	p.RLock()
 	address := net.JoinHostPort(p.settings.MulticastAddress, p.settings.Port)
 	portNum := p.settings.portNum

--- a/peerdiscovery.go
+++ b/peerdiscovery.go
@@ -62,11 +62,11 @@ type Settings struct {
 	// Delay is the amount of time between broadcasts. The default delay is 1 second.
 	Delay time.Duration
 	// TimeLimit is the amount of time to spend discovering, if the limit is not reached.
-	// A negative limit indiciates scanning until the limit was reached or, if an
+	// A negative limit indicates scanning until the limit was reached or, if an
 	// unlimited scanning was requested, no timeout.
 	// The default time limit is 10 seconds.
 	TimeLimit time.Duration
-	// StopChan is a channel to stop the peer discvoery immediatley after reception.
+	// StopChan is a channel to stop the peer discovery immediately after reception.
 	StopChan chan struct{}
 	// AllowSelf will allow discovery the local machine (default false)
 	AllowSelf bool


### PR DESCRIPTION
This was done with cspell; I'd be happy to set up a GitHub action to check each commit automatically as well, if desired!